### PR TITLE
Make break-before or break-after configurable

### DIFF
--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -344,6 +344,10 @@ open class Simulator(
         }
     }
 
+    fun setBreakBeforeInstruction(set: Boolean) {
+        settings.breakBeforeInstruction = set;
+    }
+
     /* TODO Make this more efficient while robust! */
     fun atBreakpoint(): Boolean {
         val location = (getPC() - MemorySegments.TEXT_BEGIN).toLong()
@@ -354,7 +358,11 @@ open class Simulator(
         }
 //        return ebreak || breakpoints[inst]
 //        return ebreak || breakpoints.contains(location.toInt())
-        return ebreak xor breakpoints.contains(location.toInt())
+        if (settings.breakBeforeInstruction) {
+            return ebreak xor breakpoints.contains(location.toInt())
+        } else {
+            return ebreak xor breakpoints.contains(location.toInt() - 4)
+        }
     }
 
     fun getPC() = state.getPC()

--- a/simulator/SimulatorSettings.kt
+++ b/simulator/SimulatorSettings.kt
@@ -12,5 +12,6 @@ data class SimulatorSettings(
     var ASLR: Boolean = false,
     var NX_bit: Boolean = false,
     var allowAccessBtnStackHeap: Boolean = false,
-    var max_histroy: Int = -1
+    var max_histroy: Int = -1,
+    var breakBeforeInstruction: Boolean = false
 )


### PR DESCRIPTION
Currently venus breaks after an instruction. Make this configurable to be before the instruction by a setting and default is the current behavior.

@ThaumicMekanism does that look reasonable to be a permanent solution?